### PR TITLE
UN-8536: updates for M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM unionpos/ubuntu:16.04
+FROM unionpos/ubuntu:18.04
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -21,7 +21,9 @@ RUN set -ex \
 	&& savedAptMark="$(apt-mark showmanual)" \
 	&& apt-get update && apt-get install -y --no-install-recommends \
 	dpkg-dev \
+	dirmngr \
 	gcc \
+	gpg-agent \
 	libbz2-dev \
 	libc6-dev \
 	libexpat1-dev \
@@ -94,7 +96,9 @@ RUN set -ex \
 	&& savedAptMark="$(apt-mark showmanual)" \
 	&& apt-get update && apt-get install -y --no-install-recommends \
 	dpkg-dev \
+	dirmngr \
 	gcc \
+	gpg-agent \
 	libbz2-dev \
 	libc6-dev \
 	libexpat1-dev \

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ push:
 .PHONY: push
 
 run:
-	$(DOCKER) container run --rm --platform linux/amd64 \
+	$(DOCKER) container run --rm ${DOCKER_BUILD_FLAGS} \
 		--attach STDOUT ${DOCKER_IMAGE_NAME}
 .PHONY: run
 
 it:
-	$(DOCKER) run -it --platform linux/amd64 ${DOCKER_IMAGE_NAME} /bin/bash
+	$(DOCKER) run -it ${DOCKER_BUILD_FLAGS} ${DOCKER_IMAGE_NAME} /bin/bash
 .PHONY: it

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 export DOCKER_ORG ?= unionpos
 export DOCKER_IMAGE ?= $(DOCKER_ORG)/python
-export DOCKER_TAG ?= 3.8.11
+export DOCKER_TAG ?= 3.8.11b
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
-export DOCKER_BUILD_FLAGS =
+export DOCKER_BUILD_FLAGS = --platform linux/amd64
 
 -include $(shell curl -sSL -o .build-harness "https://raw.githubusercontent.com/unionpos/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)
 
@@ -18,10 +18,10 @@ push:
 .PHONY: push
 
 run:
-	$(DOCKER) container run --rm \
+	$(DOCKER) container run --rm --platform linux/amd64 \
 		--attach STDOUT ${DOCKER_IMAGE_NAME}
 .PHONY: run
 
 it:
-	$(DOCKER) run -it ${DOCKER_IMAGE_NAME} /bin/bash
+	$(DOCKER) run -it --platform linux/amd64 ${DOCKER_IMAGE_NAME} /bin/bash
 .PHONY: it


### PR DESCRIPTION
## What and Why
Update dockerfile to support M1. 

This builds `unionpos/python:3.8.11b` (there is already an image tagged 3.8.11 so we will use this one for now to differentiate)

## Related Tickets and PRs

Fixes [UN-8536](https://tabbedout.atlassian.net/browse/UN-8536)

## Steps to Test


## Humor for Reviewer

[UN-8536]: https://tabbedout.atlassian.net/browse/UN-8536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ